### PR TITLE
Add etc data

### DIFF
--- a/py/desiperf/instperfapp/data_mgt/data_general.py
+++ b/py/desiperf/instperfapp/data_mgt/data_general.py
@@ -45,6 +45,7 @@ class DataSource():
 
         except:
             self.connect_info = "Cannot connect to DB on desi server. Cannot fetch data."
+            return None
 
     def get_exp_df(self):
         self.exp_df = self.db_query('exposure',table_type='exposure')

--- a/py/desiperf/instperfapp/data_mgt/data_handler.py
+++ b/py/desiperf/instperfapp/data_mgt/data_handler.py
@@ -80,6 +80,7 @@ class DataHandler(object):
                 df_.to_csv('./instperfapp/data/focalplane/fp_data_{}.csv'.format(i),index=False)
             self.focalplane_source = ColumnDataSource(fp_df)
 
+
         elif self.option == 'update':
             pass
 
@@ -117,7 +118,7 @@ class DataHandler(object):
             #make new file
 
     def run(self):
-        self.get_detector_data() #self.detector_source
         self.get_focalplane_data() #self.focalplane_source
+        self.get_detector_data() #self.detector_source
         self.etc_source = ColumnDataSource(self.etc_data)
 

--- a/py/desiperf/instperfapp/data_mgt/data_handler.py
+++ b/py/desiperf/instperfapp/data_mgt/data_handler.py
@@ -44,6 +44,7 @@ class DataHandler(object):
                             'guide_maxy', 'guider_combined_x', 
                             'guider_combined_y']
         self.fiberpos = pd.read_csv('./instperfapp/data/fiberpos.csv')
+        self.etc_data = pd.read_csv('./instperfapp/data/etc_output.csv')
         #self.fiberpos = Table(hdu[1].data).to_pandas()
         #print(self.fiberpos)
 
@@ -118,4 +119,5 @@ class DataHandler(object):
     def run(self):
         self.get_detector_data() #self.detector_source
         self.get_focalplane_data() #self.focalplane_source
+        self.etc_source = ColumnDataSource(self.etc_data)
 

--- a/py/desiperf/instperfapp/main.py
+++ b/py/desiperf/instperfapp/main.py
@@ -74,7 +74,8 @@ init_bt.on_click(update_data)
 layout1 = layout([[title_1],
                   [data_info],
                   [start_date, end_date],
-                  [init_bt]])
+                  [init_bt],
+                  [connect_info]])
 tab1 = Panel(child=layout1, title="Data Initilization")
 
 tab2 = fp_tab

--- a/py/desiperf/instperfapp/main.py
+++ b/py/desiperf/instperfapp/main.py
@@ -51,6 +51,7 @@ def update_data():
     print("You must run this on the desi server")
     DH = DataHandler(option='init')
     DH.run()
+    connect_info.text = DH.DS.connect_info
     fp_tab, pp_tab, gp_tab, tp_tab, dp_tab = init_pages(DH)
     tab2.children = fp_tab
     tab3.children = pp_tab
@@ -63,6 +64,7 @@ data_info = Div(text="Data is available for the dates listed below. If you want 
 start_date = TextInput(title='Start Date', value=DH.start_date)
 end_date = TextInput(title='End Date', value=DH.start_date)
 init_bt = Button(label="Initialize Data", button_type='primary', width=300)
+connect_info = Div(text=DH.DS.connect_info, width=300)
 
 fp_tab, pp_tab, gp_tab, tp_tab, dp_tab = init_pages(DH)
 init_bt.on_click(update_data)

--- a/py/desiperf/instperfapp/pages/positioner.py
+++ b/py/desiperf/instperfapp/pages/positioner.py
@@ -42,10 +42,9 @@ class PosAccPage():
         #docstring
         this_layout = layout([[self.plots.header],
                         [self.pos_select, self.x_select, self.y_select, self.btn],
-                        [self.corr],
+                        [self.corr,self.scatt],
                         [self.ts1],
-                        [self.ts2],
-                        [self.scatt]])
+                        [self.ts2]])
         tab = Panel(child=this_layout, title=self.plots.title)
         return tab
 

--- a/py/desiperf/instperfapp/pages/tput.py
+++ b/py/desiperf/instperfapp/pages/tput.py
@@ -8,7 +8,7 @@ from static.plots import Plots
 
 class TputPage():
 	def __init__(self, datahandler):
-		self.plots = Plots('Throughput Performance', source=None)
+		self.plots = Plots('Throughput Performance', source=datahandler.etc_source)
 		self.btn = Button(label='OK', button_type='primary',width=200)
 		self.txt = PreText(text="This is a sentence")
 		self.data_source = self.plots.data_source


### PR DESCRIPTION
The changes in this pull request should help initial development of the throughput page. This will use the etc_output.csv file generated by Paul. The data source for the tput page now contains this data.

* Added etc_source to data_handler
* Added this source to tput.py

Also changed a couple things recommended by Paul from the earlier pull request

* try/except loop for connecting to database. Sends a message to the main page saying if this occurs
* Found that message isn't really working yet, will re-address it in a future pull request
* Moved location of focalplane plot on pages/positioner.py