### PR TITLE
Catagories for Attributes

### DIFF
--- a/py/desiperf/instperfapp/pages/focalplane.py
+++ b/py/desiperf/instperfapp/pages/focalplane.py
@@ -10,6 +10,7 @@ import numpy as np
 from datetime import datetime
 
 from static.plots import Plots
+from static.attributes import attributes
 from scipy import stats
 
 
@@ -19,19 +20,14 @@ class FocalPlanePage(Plots):
         self.description = Div(text='These plots show the average behavior across the whole focal plate for a given time or exposure.', 
                                 width=800, style=self.text_style)
 
-        self.default_options = ['datetime','EXPID', 'max_blind', 'MAX_BLIND', 'MAX_BLIND_95',
-                                'RMS_BLIND', 'RMS_BLIND_95', 'MAX_CORR', 'MAX_CORR_95', 'RMS_CORR',
-                                'RMS_CORR_95',
-                                'targtra','targtdec', 'exptime', 'airmass', 'mountha', 'mountaz',
-                                'domeaz',  'moonra','moondec',   'mirror_avg_temp', 
-                                'air_temp', 'air_dewpoint', 'air_flow', 'mirror_temp', 'truss_temp', 'wind_speed',
-                                'wind_direction', 'humidity', 'pressure', 'temperature','dewpoint',  'gust', 'fan_on', 
-                                'temp_degc', 'exptime_sec', 'psf_pixels', 'seeing']
+        self.default_catagories = list(attributes.keys())
 
+        self.default_options = attributes
 
     def page_layout(self):
         this_layout = layout([[self.header],
                               [self.description],
+                              [self.x_cat_select, self.y_cat_select],
                               [self.x_select, self.y_select, self.btn],
                               [self.bin_option, self.save_btn],
                               [self.bin_slider, self.replot_btn, self.data_det_option],
@@ -44,9 +40,13 @@ class FocalPlanePage(Plots):
     def run(self):
         self.x_options = self.default_options
         self.y_options = self.default_options
-        self.prepare_layout()
-        self.x_select.value = 'MAX_BLIND'
-        self.y_select.value = 'airmass'
+        self.x_cat_options = self.default_catagories
+        self.y_cat_options = self.default_catagories
+        self.prepare_layout_two_menus()
+        self.x_cat_select.value = self.default_catagories[0]
+        self.y_cat_select.value = self.default_catagories[1]
+        self.x_select.value = self.default_options[self.default_catagories[0]][0]
+        self.y_select.value = self.default_options[self.default_catagories[1]][0]
         self.get_data('datetime',self.x_select.value, self.y_select.value, other_attr = ['EXPID'])
         self.page_tooltips = [
             ("exposure","@EXPID"),

--- a/py/desiperf/instperfapp/pages/guiding.py
+++ b/py/desiperf/instperfapp/pages/guiding.py
@@ -7,6 +7,7 @@ from bokeh.plotting import figure
 import pandas as pd 
 
 from static.plots import Plots
+from static.attributes import attributes
 
 class GuidingPage(Plots):
     def __init__(self, datahandler):
@@ -14,15 +15,15 @@ class GuidingPage(Plots):
         self.description = Div(text='These plots show the behavior of the GFA cameras during a given time or exposure.', 
                                 width=800, style=self.text_style)
 
-        self.default_options = ['datetime','EXPID','meanx', 'meany', 'meanx2', 'meany2', 'meanxy', 'maxx', 'maxy',
-                                'guider_centroids', 'combined_x', 'combined_y', 'airmass', 'domeaz', 'moonra','moondec', 
-                                'air_temp',  'mirror_temp', 'wind_speed','wind_direction', 'humidity', 'pressure', 'temperature',
-                                'dewpoint', 'fan_on', 'temp_degc', 'exptime_sec', 'psf_pixels', 'guider_summary', 'duration','seeing.1', ]
+        self.default_catagories = list(attributes.keys())
+
+        self.default_options = attributes
 
 
     def page_layout(self):
         this_layout = layout([[self.header],
                       [self.description],
+                      [self.x_cat_select, self.y_cat_select],
                       [self.x_select, self.y_select, self.btn],
                       [self.bin_option, self.save_btn],
                       [self.bin_slider, self.replot_btn, self.data_det_option],
@@ -36,9 +37,13 @@ class GuidingPage(Plots):
     def run(self):
         self.x_options = self.default_options
         self.y_options = self.default_options
-        self.prepare_layout()
-        self.x_select.value = 'meanx'
-        self.y_select.value = 'airmass'
+        self.x_cat_options = self.default_catagories
+        self.y_cat_options = self.default_catagories
+        self.prepare_layout_two_menus()
+        self.x_cat_select.value = self.default_catagories[0]
+        self.y_cat_select.value = self.default_catagories[1]
+        self.x_select.value = self.default_options[self.default_catagories[0]][0]
+        self.y_select.value = self.default_options[self.default_catagories[1]][0]
         self.get_data('datetime',self.x_select.value, self.y_select.value, other_attr=['EXPID'])
         self.page_tooltips = [
             ("exposure","@EXPID"),

--- a/py/desiperf/instperfapp/static/attributes.py
+++ b/py/desiperf/instperfapp/static/attributes.py
@@ -1,0 +1,43 @@
+attributes = {
+	'Exposures':['EXPID','data_location','targtra','targtdec','skyra','skydec','deltara','deltadec',
+	'reqtime','exptime','flavor','program','lead','focus','airmass','mountha','zd','mountaz','domeaz',
+	'spectrographs','s2n','transpar','skylevel','zenith','mjd_obs','date_obs','night','moonra','moondec',
+	'parallactic','mountel','sequence','obstype'],
+
+	'GFA data':['ccdtemp_mean','hotpeltier_mean','coldpeltier_mean','filter_mean','humid2_mean','humid3_mean',
+	'fpga_mean','camerahumid_mean','cameratemp_mean'],
+
+	'Guider':['combined_x','combined_y','guider_time_recorded','duration','expid','seeing','frames','meanx','meany',
+	'meanx2','meany2','meanxy','maxx','maxy'],
+
+	'Telemetry':['air_flow','air_temp','truss_temp','air_in_temp','flowrate_in','mirror_temp','probe1_temp',
+	'probe2_temp','air_dewpoint','air_out_temp','decbore_temp','flowrate_out','hinge_s_temp','hinge_w_temp',
+	'mirror_status','glycol_in_temp','servo_setpoint','topring_s_temp','topring_w_temp','truss_etb_temp','truss_ett_temp',
+	'truss_ntb_temp','truss_ntt_temp','truss_stb_temp','truss_sts_temp','truss_stt_temp','truss_stt_temp',
+	'truss_tsb_temp','truss_tsm_temp','truss_tst_temp','truss_wtb_temp','truss_wtt_temp','casscage_i_temp',
+	'casscage_o_temp','chimney_ib_temp','chimney_im_temp','chimney_it_temp','chimney_os_temp','chimney_ow_temp',
+	'glycol_out_temp','mirror_avg_temp','mirror_eib_temp','mirror_eit_temp','mirror_eob_temp','mirror_eot_temp',
+	'mirror_nib_temp','mirror_nit_temp','mirror_nob_temp','mirror_not_temp','mirror_rtd_temp','mirror_sib_temp',
+	'mirror_sit_temp','mirror_sob_temp','mirror_sot_temp','mirror_wib_temp','mirror_wit_temp','mirror_wob_temp',
+	'mirror_wob_temp','probe1_humidity','probe2_humidity','primarycell_i_temp','primarycell_o_temp',
+	'mirror_desired_temp','telescope_timestamp','centersection_i_temp','centersection_o_temp','guts','split',
+	'dewpoint','humidity','pressure','wind_speed','temperature','wind_direction','tower_timstamp','C_floor',
+	'SCR_roof','platform','wind_direction','LCR_floor','lights_low','shack_wall','stairs_mid','LCR_ceiling',
+	'lights_high','mirror_cover','stairs_lower','stairs_upper','utility_room','LCR_ambient_N','LCR_ambient_S',
+	'shack_ceiling','shutter_lower','shutter_upper','dome_timestamp','telescope_base','utility_N_wall',
+	'dome_back_lower','dome_back_upper','dome_left_lower','dome_left_upper','SCR_E_wall_coude','SCR_roof_ambient',
+	'dome_right_lower','dome_right_upper','LCR_N_wall_inside','LCR_W_wall_inside','LCR_N_wall_outside',
+	'LCR_W_wall_outside','SCR_E_wall_computer'],
+
+	'Hexapod':['rot_rate','hex_status','rot_offset','rot_enabled','rot_interval','hex_trim_0','hex_position_0',
+	'hex_trim_1','hex_position_1','hex_trim_2','hex_position_2','hex_trim_3','hex_position_3','hex_trim_4',
+	'hex_position_4','hex_trim_5','hex_position_5','hex_tweak'],
+
+	'ADC':['adc_home1','adc_home2','adc_nrev1','adc_nrev2','adc_angle1','adc_angle2'],
+
+	'FVC':['shutter_open','fan_on','temp_degc','exptime_sec','psf_pixels','fvc_time_recorded'],
+
+	'Spectrograph':['nir_camera_temp_mean','nir_camera_humidity_mean','red_camera_temp_mean',
+	'red_camera_humidity_mean','blue_camera_temp_mean','blue_camera_humidity_mean','bench_cryo_temp_mean',
+	'bench_nir_temp_mean','bench_coll_temp_mean','ieb_temp_mean']
+}

--- a/py/desiperf/instperfapp/static/plots.py
+++ b/py/desiperf/instperfapp/static/plots.py
@@ -1,5 +1,5 @@
 from bokeh.io import curdoc
-from bokeh.models import Button, CheckboxButtonGroup, PreText, Select, Slider, CheckboxGroup, ColumnDataSource, RadioGroup
+from bokeh.models import Button, CheckboxButtonGroup, PreText, Select, Slider, CheckboxGroup, ColumnDataSource, RadioGroup, CustomJS
 from bokeh.models.widgets.markups import Div
 from bokeh.plotting import figure
 from scipy import stats
@@ -51,8 +51,29 @@ class Plots:
                     ("(x,y)", "($x, $y)")]
 
     def prepare_layout(self):
-        self.x_select = Select(title='Option 1', options=self.x_options)
-        self.y_select = Select(title='Option 2', options=self.y_options)
+        self.x_select = Select(title='X Attribute', options=self.x_options)
+        self.y_select = Select(title='Y Attribute', options=self.y_options)
+
+    def prepare_layout_two_menus(self):
+        self.x_cat_select = Select(title='X Catagory',options=self.x_cat_options)
+        self.y_cat_select = Select(title='Y Catagory',options=self.y_cat_options)
+        self.x_select = Select(title='X Attribute', options=self.x_options[self.x_cat_options[0]])
+        self.y_select = Select(title='Y Attribute', options=self.y_options[self.y_cat_options[1]])  
+        x_attribute_callback = CustomJS(args=dict(x_select=self.x_select),code = """
+            const opts = %s
+            console.log('changed selected options',cb_obj.value)
+            x_select.options = opts[cb_obj.value]
+            """ %self.x_options)
+
+        self.x_cat_select.js_on_change('value',x_attribute_callback)
+
+        y_attribute_callback = CustomJS(args=dict(y_select=self.y_select),code = """
+            const opts = %s
+            console.log('changed selected options',cb_obj.value)
+            y_select.options = opts[cb_obj.value]
+            """ %self.y_options)
+
+        self.y_cat_select.js_on_change('value',y_attribute_callback)
 
     def update(self):
         self.get_data(self.xx, self.x_select.value, self.y_select.value, self.other_attr, update=True)


### PR DESCRIPTION
- Created new file (static/attributes.py). The file contains a python dictionary where the keys are the Attribute Catagories and the values are lists with the Attributes of corresponding Catagories
- Added new fuction to static/pages.py, called 'prepare_layout_two_menus,' which creates two separate dropdown menus for both X and Y coordinates. The top menu, labeled 'Catagory,' holds the different attribute catagories. The bottom menu, labeled 'attributes,' holds the attributes in the selected Catagory. Changing the selection in the top menu, will change the available options for the bottom menu.
- Updated FocalPlane and Guiding tabs (pages/focalplane.py and pages/guiding.py) with the new function. Both tabs have access to ALL Catagories and Attributes at this time.