### PR TITLE
Resolved bug that would not allow the app to start

### DIFF
--- a/py/desiperf/instperfapp/data_mgt/data_handler.py
+++ b/py/desiperf/instperfapp/data_mgt/data_handler.py
@@ -32,6 +32,7 @@ class DataHandler(object):
         fp_df['obstype'] = fp_df['obstype'].astype('str').str.upper() 
         fp_df = fp_df[(fp_df.datetime >= self.start_date)&(fp_df.datetime <= self.end_date)]
         fp_df.columns = [x.upper() for x in fp_df.columns]
+        fp_df = fp_df.loc[:,~fp_df.columns.duplicated()]
         self.focalplane_source = ColumnDataSource(fp_df)
 
     def get_detector_data(self):

--- a/py/desiperf/instperfapp/static/plots.py
+++ b/py/desiperf/instperfapp/static/plots.py
@@ -31,9 +31,9 @@ class Plots:
         self.bin_data = None
 
         self.plot_trend_option = CheckboxGroup(labels=['Plot Trend Line'])
-        self.mp_tl_det = PreText(text=' ',width=250)
-        self.ts1_tl_det = PreText(text=' ',width=250)
-        self.ts2_tl_det = PreText(text=' ',width=250)
+        self.mp_tl_det = PreText(text=' ',width=300)
+        self.ts1_tl_det = PreText(text=' ',width=300)
+        self.ts2_tl_det = PreText(text=' ',width=300)
 
         self.pos_tooltips = [
                     ("fiber","@FIBER"),


### PR DESCRIPTION
-Fixed bug that would not allow the app to start
-Added a line in the code that removes a column from the fp_df. The column was 'expid' in the fpa_data_#.csv and was changed into 'EXPID' in the data handler, which confused main.py as there were 2 'EXPID' colmuns.
-Also, as a minor note changed the width of the PreText boxes with the trendline slopes, in order to make sure they don't overlap with each other.